### PR TITLE
사망 시 이동 버그 개선

### DIFF
--- a/Assets/Animation/_PlayerController.controller
+++ b/Assets/Animation/_PlayerController.controller
@@ -612,31 +612,6 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1101 &33664770866304475
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 3
-    m_ConditionEvent: Move
-    m_EventTreshold: 0.4
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 0}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 1
-  serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 1
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
 --- !u!1101 &1640117994178256365
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -805,7 +780,6 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -8589960329738201662}
-  - {fileID: 33664770866304475}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/Scripts/Town/MyPlayer.cs
+++ b/Assets/Scripts/Town/MyPlayer.cs
@@ -211,7 +211,7 @@ public class MyPlayer : MonoBehaviour
     // 충돌한 위치로 NavMeshAgent를 이동시킴 (agent.SetDestination(rayHit.point);
     private void HandleInput()
     {
-        if (player.IsStun || !isReadyESystem)
+        if (player.IsStun || player.IsDead || !isReadyESystem)
             return;
 
         if (Input.GetMouseButtonDown(0) && !eSystem.IsPointerOverGameObject())
@@ -274,7 +274,7 @@ public class MyPlayer : MonoBehaviour
 
     private void MoveAndSendMovePacket()
     {
-        if (player.IsStun)
+        if (player.IsStun || player.IsDead)
             return;
 
         // 플레이어 이동시키기

--- a/Assets/Scripts/Town/Player.cs
+++ b/Assets/Scripts/Town/Player.cs
@@ -738,6 +738,9 @@ public class Player : MonoBehaviour
 
         if (IsMine)
         {
+            MPlayer.NavAgent.ResetPath();
+            MPlayer.NavAgent.velocity = Vector3.zero;
+
             int recallTimer = 0;
 
             while (IsDead || recallTimer <= 10)

--- a/Assets/StreamingAssets/build_info
+++ b/Assets/StreamingAssets/build_info
@@ -1,1 +1,1 @@
-Build from DESKTOP-10VULGB at 2025-03-13 오후 8:51:55
+Build from DESKTOP-10VULGB at 2025-03-13 오후 8:53:31

--- a/Assets/StreamingAssets/build_info
+++ b/Assets/StreamingAssets/build_info
@@ -1,1 +1,1 @@
-Build from DESKTOP-10VULGB at 2025-03-13 오후 7:14:45
+Build from DESKTOP-10VULGB at 2025-03-13 오후 8:51:55

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:563e8a81d3ae3c09587f7719b91776e61f5fc2f473a93ac92d752ff2c3f8dba6
-size 22169
+oid sha256:f838be4229fc2624953636bb6ac84f4e0cf64cf9712632cd8b523078a9844d53
+size 22170


### PR DESCRIPTION
### 버전은 1.0.91
1. 다른 요소로 IsStun 해제 시 사망 시 이동 가능
- IsDead 상태일 때 역시 모든 Input 받지 못하도록 수정
- Death 코루틴 시 NavAgent를 ResetPath() 실행하고, velocity를 Vector3.zero로 정지시킴
- Death 애니메이션의 Exit 트랜지션 중 Move 파라미터로 판단하던 트랜지션 제거